### PR TITLE
Path resolution fixes for DatabricksArtifactRepository

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -54,15 +54,16 @@ class DatabricksArtifactRepository(ArtifactRepository):
                                   error_code=INVALID_PARAMETER_VALUE)
         self.run_id = self._extract_run_id(self.artifact_uri)
 
+        # Fetch the artifact root for the MLflow Run associated with `artifact_uri` and compute
+        # the path of `artifact_uri` relative to the MLflow Run's artifact root
+        # (the `run_relative_artifact_repo_root_path`). All operations performed on this artifact
+        # repository will be performed relative to this computed location
         artifact_repo_root_path = extract_and_normalize_path(artifact_uri)
         run_artifact_root_uri = self._get_run_artifact_root(self.run_id)
         run_artifact_root_path = extract_and_normalize_path(run_artifact_root_uri)
-        if artifact_repo_root_path == run_artifact_root_path:
-            self.run_relative_artifact_repo_root_path = ""
-        else:
-            self.run_relative_artifact_repo_root_path = posixpath.relpath(
-                path=artifact_repo_root_path, start=run_artifact_root_path
-            )
+        self.run_relative_artifact_repo_root_path = posixpath.relpath(
+            path=artifact_repo_root_path, start=run_artifact_root_path
+        )
 
     @staticmethod
     def _extract_run_id(artifact_uri):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -13,7 +13,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 from mlflow.protos.databricks_artifacts_pb2 import DatabricksMlflowArtifactsService, \
     GetCredentialsForWrite, GetCredentialsForRead, ArtifactCredentialType
-from mlflow.protos.service_pb2 import MlflowService, ListArtifacts
+from mlflow.protos.service_pb2 import MlflowService, GetRun, ListArtifacts
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path, yield_file_in_chunks
@@ -54,6 +54,16 @@ class DatabricksArtifactRepository(ArtifactRepository):
                                   error_code=INVALID_PARAMETER_VALUE)
         self.run_id = self._extract_run_id(self.artifact_uri)
 
+        artifact_repo_root_path = extract_and_normalize_path(artifact_uri)
+        run_artifact_root_uri = self._get_run_artifact_root(self.run_id)
+        run_artifact_root_path = extract_and_normalize_path(run_artifact_root_uri)
+        if artifact_repo_root_path == run_artifact_root_path:
+            self.run_relative_artifact_repo_root_path = ""
+        else:
+            self.run_relative_artifact_repo_root_path = posixpath.relpath(
+                path=artifact_repo_root_path, start=run_artifact_root_path
+            )
+
     @staticmethod
     def _extract_run_id(artifact_uri):
         """
@@ -75,6 +85,12 @@ class DatabricksArtifactRepository(ArtifactRepository):
         response_proto = api.Response()
         return call_endpoint(get_databricks_host_creds(),
                              endpoint, method, json_body, response_proto)
+
+    def _get_run_artifact_root(self, run_id):
+        json_body = message_to_json(GetRun(run_id=run_id))
+        run_response = self._call_endpoint(MlflowService,
+                                           GetRun, json_body)
+        return run_response.run.info.artifact_uri
 
     def _get_write_credentials(self, run_id, path=None):
         json_body = message_to_json(GetCredentialsForWrite(run_id=run_id, path=path))
@@ -187,8 +203,13 @@ class DatabricksArtifactRepository(ArtifactRepository):
         basename = os.path.basename(local_file)
         artifact_path = artifact_path or ""
         artifact_path = posixpath.join(artifact_path, basename)
-        write_credentials = self._get_write_credentials(self.run_id, artifact_path)
-        self._upload_to_cloud(write_credentials, local_file, artifact_path)
+        if len(artifact_path) > 0:
+            run_relative_artifact_path = posixpath.join(
+                self.run_relative_artifact_repo_root_path, artifact_path)
+        else:
+            run_relative_artifact_path = self.run_relative_artifact_repo_root_path
+        write_credentials = self._get_write_credentials(self.run_id, run_relative_artifact_path)
+        self._upload_to_cloud(write_credentials, local_file, run_relative_artifact_path)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         artifact_path = artifact_path or ""
@@ -203,7 +224,12 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 self.log_artifact(file_path, artifact_subdir)
 
     def list_artifacts(self, path=None):
-        json_body = message_to_json(ListArtifacts(run_id=self.run_id, path=path))
+        if path:
+            run_relative_path = posixpath.join(
+                self.run_relative_artifact_repo_root_path, path)
+        else:
+            run_relative_path = self.run_relative_artifact_repo_root_path
+        json_body = message_to_json(ListArtifacts(run_id=self.run_id, path=run_relative_path))
         artifact_list = self._call_endpoint(MlflowService, ListArtifacts, json_body).files
         # If `path` is a file, ListArtifacts returns a single list element with the
         # same name as `path`. The list_artifacts API expects us to return an empty list in this
@@ -212,13 +238,17 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 and not artifact_list[0].is_dir:
             return []
         infos = list()
-        for file in artifact_list:
-            artifact_size = None if file.is_dir else file.file_size
-            infos.append(FileInfo(file.path, file.is_dir, artifact_size))
+        for output_file in artifact_list:
+            file_rel_path = posixpath.relpath(
+                path=output_file.path, start=self.run_relative_artifact_repo_root_path)
+            artifact_size = None if output_file.is_dir else output_file.file_size
+            infos.append(FileInfo(file_rel_path, output_file.is_dir, artifact_size))
         return infos
 
     def _download_file(self, remote_file_path, local_path):
-        read_credentials = self._get_read_credentials(self.run_id, remote_file_path)
+        run_relative_remote_file_path = posixpath.join(
+            self.run_relative_artifact_repo_root_path, remote_file_path)
+        read_credentials = self._get_read_credentials(self.run_id, run_relative_remote_file_path)
         self._download_from_cloud(read_credentials.credentials, local_path)
 
     def delete_artifacts(self, artifact_path=None):


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR modifies `DatabricksArtifactRepository` to compute the relative path of the repository's `artifact_uri` to the associated MLflow Run's artifact root. All operations are then performed relative to this artifact root.

For example, if the repository is instantiated with the uri `dbfs:/databricks/mlflow-tracking/<EXP_ID>/<RUN_ID>/artifacts/my/subpath`, all LIST/UPLOAD/DOWNLOAD operations will be performed relative to this location. Calling `list_artifacts("foo")` will list the artifacts under `dbfs:/databricks/mlflow-tracking/<EXP_ID>/<RUN_ID>/artifacts/my/subpath/foo`. Previously, artifacts were listed under `dbfs:/databricks/mlflow-tracking/<EXP_ID>/<RUN_ID>/artifacts` (the run root); this worked because `list_artifacts()` returned artifact paths relative to the run root, rather than relative to the artifact repo root.

@arjundc-db Let me know if this makes sense and please leave comments / questions! If you can add relevant tests for listing behavior (e.g., tests ensuring that the repo returns paths relative to the artifact repo root rather than the run root), that would be awesome!

Currently missing:
- Tests
- Possibly comments (@arjundc-db let me know if you can identify any additional places where comments would be helpful)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
